### PR TITLE
Add gpg flag to prompt for a GPG key ID when adding a user

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Usage:
 
 Flags:
   --global              Set user as global.
+  --gpg                 Prompt for a GPG key ID.
 ```
 
 ## LICENSE

--- a/user.go
+++ b/user.go
@@ -7,8 +7,9 @@ import (
 )
 
 type User struct {
-	Name  string `json:"Name"`
-	Email string `json:"Email"`
+	Name     string `json:"Name"`
+	Email    string `json:"Email"`
+	GpgKeyID string `json:"GpgKeyId"`
 }
 
 func UsersToString(users []User) []string {
@@ -38,14 +39,16 @@ func ListUser() ([]User, error) {
 	return config.Users, nil
 }
 
-func CreateUser(name, email string) error {
+func CreateUser(name, email, gpgKeyID string) error {
 	configPath, err := ConfigPath()
 	if err != nil {
 		return err
 	}
 
+	user := User{Name: name, Email: email, GpgKeyID: gpgKeyID}
+
 	if !IsExist(configPath) {
-		if err := CreateConfig(Config{Users: []User{User{Name: name, Email: email}}}); err != nil {
+		if err := CreateConfig(Config{Users: []User{user}}); err != nil {
 			return err
 		}
 		return nil
@@ -57,9 +60,9 @@ func CreateUser(name, email string) error {
 	}
 
 	if config.Users == nil {
-		config.Users = []User{User{Name: name, Email: email}}
+		config.Users = []User{user}
 	} else {
-		config.Users = append(config.Users, User{Name: name, Email: email})
+		config.Users = append(config.Users, user)
 	}
 
 	if err := CreateConfig(config); err != nil {


### PR DESCRIPTION
Hi, thanks for the tool, it's really useful.

I'd like to use the program to configure which GPG key should be used to sign commits for a given user. I've added this capability by prompting for a GPG key ID when the `--gpg` flag is specified. I don't know whether this is a feature you're interested in integrating, but if you are, I'm open to any feedback/suggestions.

I thought it would be cool if the tool could display candidate keys in an interactive selection list, but integrating with the GPG keyring/agent seemed a bit complicated, so this PR just allows the key ID to be input as a string.