### PR TITLE
Add silent bell / bellskipper

### DIFF
--- a/bell.go
+++ b/bell.go
@@ -1,0 +1,27 @@
+package main
+
+import "os"
+
+// bellSkipper implements an io.WriteCloser that skips the terminal bell
+// character (ASCII code 7), and writes the rest to os.Stderr. It is used to
+// replace readline.Stdout, that is the package used by promptui to display the
+// prompts.
+//
+// This is a workaround for the bell issue documented in
+// https://github.com/manifoldco/promptui/issues/49.
+type bellSkipper struct{}
+
+// Write implements an io.WriterCloser over os.Stderr, but it skips the terminal
+// bell character.
+func (bs *bellSkipper) Write(b []byte) (int, error) {
+	const charBell = 7 // c.f. readline.CharBell
+	if len(b) == 1 && b[0] == charBell {
+		return 0, nil
+	}
+	return os.Stderr.Write(b)
+}
+
+// Close implements an io.WriterCloser over os.Stderr.
+func (bs *bellSkipper) Close() error {
+	return os.Stderr.Close()
+}

--- a/main.go
+++ b/main.go
@@ -48,8 +48,9 @@ const (
 
 func run() int {
 	action := promptui.Select{
-		Label: "Select action",
-		Items: []string{sel, add, del},
+		Label:  "Select action",
+		Items:  []string{sel, add, del},
+		Stdout: &bellSkipper{},
 	}
 
 	_, actionType, err := action.Run()


### PR DESCRIPTION
On Windows (and MacOS) the terminal bell is triggered when using the arrow keys to navigate the prompt. 
This disables the bell by providing a custom Stdout to the prompt which skips the bell character.