### PR TITLE
Fix issue #5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/

--- a/git.go
+++ b/git.go
@@ -1,0 +1,28 @@
+package main
+
+import "os/exec"
+
+func SetGitConfig(user User, scope Scope, users []User, selectedUserIndex int) error {
+	cmdName := exec.Command("git", "config", scope.String(), "user.name", user.Name)
+	if err := cmdName.Run(); err != nil {
+		return err
+	}
+
+	cmdMail := exec.Command("git", "config", scope.String(), "user.email", user.Email)
+	if err := cmdMail.Run(); err != nil {
+		return err
+	}
+
+	cmdGpgKey := exec.Command("git", "config", scope.String(), "user.signingkey", user.GpgKeyID)
+	if users[selectedUserIndex].GpgKeyID == "" {
+		cmdGpgKey = exec.Command("git", "config", scope.String(), "--unset", "user.signingkey")
+	}
+	if err := cmdGpgKey.Run(); err != nil {
+		// git exits with code 5 when unsetting a non-existent property
+		if exitErr, ok := err.(*exec.ExitError); !ok || exitErr.ExitCode() != 5 {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ func run() int {
 
 	action := promptui.Select{
 		Label:  "Select action",
-		Items:  []string{sel, add, del},
+		Items:  []string{sel, add, del, mod},
 		Stdout: &bellSkipper{},
 	}
 

--- a/scope.go
+++ b/scope.go
@@ -1,0 +1,12 @@
+package main
+
+type Scope int
+
+const (
+	Global Scope = iota
+	Local
+)
+
+func (s Scope) String() string {
+	return []string{"--global", "--local"}[s]
+}

--- a/user.go
+++ b/user.go
@@ -93,6 +93,27 @@ func RemoveUser(idx int, users []User) error {
 	return nil
 }
 
+func ModifyUser(idx int, newUser User) error {
+	config, err := ReadConfig()
+	if err != nil {
+		return err
+	}
+
+	if newUser.Name != "" {
+		config.Users[idx].Name = newUser.Name
+	}
+
+	if newUser.Email != "" {
+		config.Users[idx].Email = newUser.Email
+	}
+
+	if newUser.GpgKeyID != "" {
+		config.Users[idx].GpgKeyID = newUser.GpgKeyID
+	}
+
+	return CreateConfig(config)
+}
+
 func ValidateEmail(email string) error {
 	if !govalidator.IsExistingEmail(email) {
 		return errors.New("Invalid email address")

--- a/user.go
+++ b/user.go
@@ -10,13 +10,19 @@ import (
 type User struct {
 	Name     string `json:"Name"`
 	Email    string `json:"Email"`
+	Alias    string `json:"Alias"`
 	GpgKeyID string `json:"GpgKeyId"`
 }
 
 func UsersToString(users []User) []string {
 	us := make([]string, len(users))
 	for i, user := range users {
-		us[i] = fmt.Sprintf("%s <%s>", user.Name, user.Email)
+		alias := ""
+		if user.Alias != "" {
+			alias = fmt.Sprintf("[%s] ", user.Alias)
+		}
+
+		us[i] = fmt.Sprintf("%s%s <%s>", alias, user.Name, user.Email)
 	}
 
 	return us
@@ -40,13 +46,18 @@ func ListUser() ([]User, error) {
 	return config.Users, nil
 }
 
-func CreateUser(name, email, gpgKeyID string) error {
+func CreateUser(name, email, gpgKeyID, alias string) error {
 	configPath, err := ConfigPath()
 	if err != nil {
 		return err
 	}
 
-	user := User{Name: name, Email: email, GpgKeyID: gpgKeyID}
+	user := User{
+		Name:     name,
+		Email:    email,
+		GpgKeyID: gpgKeyID,
+		Alias:    alias,
+	}
 
 	if !IsExist(configPath) {
 		if err := CreateConfig(Config{Users: []User{user}}); err != nil {
@@ -68,14 +79,15 @@ func CreateUser(name, email, gpgKeyID string) error {
 			return err
 		}
 
+		err = CheckAlias(user.Alias, config.Users)
+		if err != nil {
+			return err
+		}
+
 		config.Users = append(config.Users, user)
 	}
 
-	if err := CreateConfig(config); err != nil {
-		return err
-	}
-
-	return nil
+	return CreateConfig(config)
 }
 
 func RemoveUser(idx int, users []User) error {
@@ -86,11 +98,7 @@ func RemoveUser(idx int, users []User) error {
 		newUsers = append(users[:idx], users[idx+1:]...)
 	}
 
-	if err := CreateConfig(Config{Users: newUsers}); err != nil {
-		return err
-	}
-
-	return nil
+	return CreateConfig(Config{Users: newUsers})
 }
 
 func ModifyUser(idx int, newUser User) error {
@@ -111,7 +119,38 @@ func ModifyUser(idx int, newUser User) error {
 		config.Users[idx].GpgKeyID = newUser.GpgKeyID
 	}
 
+	if newUser.Alias != "" {
+		err := CheckAlias(newUser.Alias, config.Users)
+		if err != nil {
+			return err
+		}
+
+		config.Users[idx].Alias = newUser.Alias
+	}
+
 	return CreateConfig(config)
+}
+
+func CheckUser(newUser User, config Config) error {
+	for _, user := range config.Users {
+		if user.Email == newUser.Email && user.Name == newUser.Name {
+			msg := fmt.Sprintf("User %s <%s> already exists", user.Name, user.Email)
+			return errors.New(msg)
+		}
+	}
+
+	return nil
+}
+
+func CheckAlias(alias string, users []User) error {
+	for _, user := range users {
+		if user.Alias == alias {
+			msg := fmt.Sprintf("A user with alias [%s] already exists: %s <%s>", alias, user.Name, user.Email)
+			return errors.New(msg)
+		}
+	}
+
+	return nil
 }
 
 func ValidateEmail(email string) error {
@@ -122,12 +161,13 @@ func ValidateEmail(email string) error {
 	return nil
 }
 
-func CheckUser(newUser User, config Config) error {
-	for _, user := range config.Users {
-		if user.Email == newUser.Email && user.Name == newUser.Name {
-			msg := fmt.Sprintf("User %s <%s> already exists", user.Name, user.Email)
-			return errors.New(msg)
-		}
+func ValidateModifiedEmail(email string) error {
+	if email == "" {
+		return nil
+	}
+
+	if !govalidator.IsExistingEmail(email) {
+		return errors.New("Invalid email address")
 	}
 
 	return nil


### PR DESCRIPTION
This fixes #5 

This PR fixes multiple things:

#### Option to modify existing users

```shell
Use the arrow keys to navigate: ↓ ↑ → ←
? Select action:
    Select git user
    Add new git user
    Delete git user
  > Modify git user
```

Following this you can select the user to modify

```shell
? Select git user:
  > Dog <lazy@dog.com>
    [foo] Foo <bar@baz.com>
    [rick] Rick <rick@astley.com>
```

You are then guided through updating each user option (name, email, GPG key ID and alias). Leaving an option empty results in no change for this specific option.

#### Support for aliases

When adding a new user you can specify an alias. This allows you to execute `gitsu <alias>` which immediatly sets the git user.

#### Misc

This commit also adds a default `.gitignore` for Go projects (See [here](https://github.com/github/gitignore/blob/master/Go.gitignore))

I seperated the `git config` commands into their own file and combined the 3 commands into one function called `SetGitConfig`. This cuts down on complexity in the gitsu commands and follows DRY.

#### Note
This improves on #6 and implements the proposed behaviour from @matsuyoshi30 and @BrendanThompson