### PR TITLE
Fix issue when trying to modify user profiles

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -141,7 +141,7 @@ func CreateEmptyConfigIfNeeded() (*Config, error) {
 
 // AddUser adds a new user to the config or returns an error if new user is invalid
 func (c *Config) AddUser(user *models.User) error {
-	err := c.isValidUser(user)
+	err := c.isValidUser(user, -1)
 	if err != nil {
 		return err
 	}
@@ -165,7 +165,7 @@ func (c *Config) ModifyUser(index int, modifiedUser *models.User) error {
 		modifiedUser.GpgKeyID,
 	)
 
-	err := c.isValidUser(&user)
+	err := c.isValidUser(&user, index)
 	if err != nil {
 		return err
 	}
@@ -235,12 +235,19 @@ func (c *Config) Reset() {
 }
 
 // isValidUser returns if the provided user is valid
-func (c *Config) isValidUser(newUser *models.User) error {
-	for _, user := range c.Users {
+func (c *Config) isValidUser(newUser *models.User, index int) error {
+	for i, user := range c.Users {
+		// Looking at the same profile, skip
+		if i == index {
+			continue
+		}
+
+		// Same name and email already exist
 		if user.Name == newUser.Name && user.Email == newUser.Email {
 			return fmt.Errorf("User %s <%s> already exists", user.Name, user.Email)
 		}
 
+		// Alias already exists
 		if newUser.Alias != "" && user.Alias == newUser.Alias {
 			return fmt.Errorf(
 				"A user with alias [%s] already exists: %s <%s>",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -197,7 +197,7 @@ func (c *Config) SelectUser(index int) (*models.User, error) {
 
 // SelectDefaultUser returns the default user or nil if there is no default user
 func (c *Config) SelectDefaultUser() (*models.User, error) {
-	user, err := c.SelectUserByAlias("default")
+	user, err := c.SelectUserByAlias(constants.DefaultAlias)
 	if err != nil {
 		return nil, ErrNoDefaultUser
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -197,12 +197,11 @@ func (c *Config) SelectUser(index int) (*models.User, error) {
 
 // SelectDefaultUser returns the default user or nil if there is no default user
 func (c *Config) SelectDefaultUser() (*models.User, error) {
-	for _, user := range c.Users {
-		if user.Alias == constants.DefaultAlias {
-			return &user, nil
-		}
+	user, err := c.SelectUserByAlias("default")
+	if err != nil {
+		return nil, ErrNoDefaultUser
 	}
-	return nil, ErrNoDefaultUser
+	return user, nil
 }
 
 // SelectUserByAlias returns a user by alias or nil if there is no such user


### PR DESCRIPTION
This PR introduces:

- Optimized user profile selection and removing duplicate code
- Fix issue while modifying user profiles

## Fix

When trying to modify a user the changes were rejected because a user with the same alias already exists. This fixes the issue by looking at the index of the changed user. If we look at the same user we skip validation.