### PR TITLE
Fix an error with signing key on `gitsu select`

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -71,8 +71,13 @@ func gitGPGKeyIDCommand(gpgKeyID string, scope models.Scope) error {
 	}
 
 	out, err := cmd.Output()
-	if exitErr, ok := err.(*exec.ExitError); !ok || exitErr.ExitCode() != 5 {
-		return fmt.Errorf("%s: %w", out, err)
+
+	if err != nil {
+		exit, ok := err.(*exec.ExitError)
+		if !ok || exit.ExitCode() != 5 {
+			return fmt.Errorf("%s: %w", out, err)
+		}
 	}
+
 	return nil
 }


### PR DESCRIPTION
The previous logic does not check that `err` isn't nil before attempting a conversion to `exec.ExitError`.

The output was

```console
$ gitsu select
# select the correct user
failed to set / unset user.signingkey option via git: : %!w(<nil>)
exit status 1
```